### PR TITLE
dark theme staff page changes

### DIFF
--- a/app/views/default/staff.blade.php
+++ b/app/views/default/staff.blade.php
@@ -6,7 +6,7 @@
 
 			<div class="thumbnail" style="height: 221px">
 				<img src="/api/dj-image/{{ $s["id"] }}" alt="{{{ $s["djname"] }}}" height="150" width="150" style="max-height: 150px">
-				<div class="text-center">
+				<div class="text-center staff-name">
 					{{{ $s["djname"] }}}
 				</div>
 

--- a/public/css/dark.css
+++ b/public/css/dark.css
@@ -24,6 +24,11 @@ code {
      color: rgba(255, 255, 255, 0.75);
 }
 
+.staff-name {
+     color: #686868;
+}
+
+
 .text-danger {
      color: #A15755;
 }


### PR DESCRIPTION
Changed views/default so I wouldn't have to do it again for every time I did a dark theme. Doesn't change default white theme in any way visually.

Should probably add staff page to navbar already? It's got all it needs for now.
