### PR TITLE
add thread under queue when dj is on

### DIFF
--- a/app/views/default/home.blade.php
+++ b/app/views/default/home.blade.php
@@ -188,7 +188,7 @@
 					@endforeach
 				</ul>
 				<div class="well well-lg" id="dj-mode" style="display: none">
-					<h1 class="text-center">Queue Unavailable</h1>
+					<h1 class="text-center thread"><a href="{{{ $status["thread"] }}}">Thread up!</a></h1>
 				</div>
 			</div>
 		</div>

--- a/public/css/dark.css
+++ b/public/css/dark.css
@@ -90,8 +90,8 @@ hr {
 }
 
 .thumbnail, #cooldown {
-     background-color: #1B1B1B;
-     border-color: rgba(27, 27, 27, 0.1);
+     background-color: transparent;
+     border-color: transparent;
 }
 
 .progress {


### PR DESCRIPTION
I don't even know if this works because vagrant NEVER FUCKING WORKS FOR NO REASON

should only display when dj is on (better than "queue unavailable")

although it probably doesn't work as intended if dj has no thread, lol (should probably make it print something else instead of a link if thread is null)

something like https://gist.github.com/tamamoe/2bf005584b29087d751c
