### PR TITLE
Fix time in /queue and /last-played

### DIFF
--- a/app/views/default/lastplayed.blade.php
+++ b/app/views/default/lastplayed.blade.php
@@ -3,7 +3,7 @@
 	<div class="container main content">
 		<h1 class="text-center">Last Played</h1>
 
-		<ul class="time-list list-group col-md-8 col-md-offset-2">
+		<ul class="time-list list-group col-md-8 col-md-offset-2 col-xs-12">
 			@foreach ($lastplayed as $lp)
 				<li class="list-group-item">
 					<time datetime="{{{ date(DATE_ISO8601, $lp["time"]) }}}">{{{ date("H:i:s", $lp["time"]) }}}</time>

--- a/app/views/default/lastplayed.blade.php
+++ b/app/views/default/lastplayed.blade.php
@@ -3,11 +3,11 @@
 	<div class="container main content">
 		<h1 class="text-center">Last Played</h1>
 
-		<ul class="list-group col-md-8 col-md-offset-2">
+		<ul class="time-list list-group col-md-8 col-md-offset-2">
 			@foreach ($lastplayed as $lp)
 				<li class="list-group-item">
 					<time datetime="{{{ date(DATE_ISO8601, $lp["time"]) }}}">{{{ date("H:i:s", $lp["time"]) }}}</time>
-					<span style="padding-left: 25px">{{{ $lp["meta"] }}}</span>
+					<span>{{{ $lp["meta"] }}}</span>
 				</li>
 			@endforeach
 		</ul>

--- a/app/views/default/lastplayed.blade.php
+++ b/app/views/default/lastplayed.blade.php
@@ -6,7 +6,7 @@
 		<ul class="list-group col-md-8 col-md-offset-2">
 			@foreach ($lastplayed as $lp)
 				<li class="list-group-item">
-					<span title="{{{ date(DATE_ISO8601, $lp["time"]) }}}">{{{ date("H:i:s", $lp["time"]) }}}</span>
+					<time datetime="{{{ date(DATE_ISO8601, $lp["time"]) }}}">{{{ date("H:i:s", $lp["time"]) }}}</time>
 					<span style="padding-left: 25px">{{{ $lp["meta"] }}}</span>
 				</li>
 			@endforeach

--- a/app/views/default/queue.blade.php
+++ b/app/views/default/queue.blade.php
@@ -3,7 +3,7 @@
 	<div class="container main content">
 		<h1 class="text-center">Queue</h1>
 
-		<ul class="time-list list-group col-md-8 col-md-offset-2">
+		<ul class="time-list list-group col-md-8 col-md-offset-2 col-xs-12">
 			@foreach ($queue as $q)
 				@if ($q["type"] > 0)
 					<li class="list-group-item list-group-item-info">

--- a/app/views/default/queue.blade.php
+++ b/app/views/default/queue.blade.php
@@ -3,7 +3,7 @@
 	<div class="container main content">
 		<h1 class="text-center">Queue</h1>
 
-		<ul class="list-group col-md-8 col-md-offset-2">
+		<ul class="time-list list-group col-md-8 col-md-offset-2">
 			@foreach ($queue as $q)
 				@if ($q["type"] > 0)
 					<li class="list-group-item list-group-item-info">
@@ -11,7 +11,7 @@
 					<li class="list-group-item">
 				@endif
 					<time datetime="{{{ date(DATE_ISO8601, $q["time"]) }}}">{{{ date("H:i:s", $q["time"]) }}}</time>
-					<span style="padding-left: 25px">{{{ $q["meta"] }}}</span>
+					<span>{{{ $q["meta"] }}}</span>
 				</li>
 			@endforeach
 		</ul>

--- a/app/views/layouts/postscript.blade.php
+++ b/app/views/layouts/postscript.blade.php
@@ -190,9 +190,12 @@
 		 */
 		function replaceTimeZones($section) {
 			if ($section.attr('data-uri') == '/queue' || $section.attr('data-uri') == '/last-played') {
+				var today = new Date();
+				today.setHours(0,0,0,0);
+
 				$section.find('time').each(function(){
 					var d = new Date(this.getAttribute('datetime'));
-					this.firstChild.nodeValue = d.toLocaleTimeString();
+					this.firstChild.nodeValue = d < today ? d.toLocaleString() : d.toLocaleTimeString();
 				});
 			}
 		}

--- a/app/views/layouts/postscript.blade.php
+++ b/app/views/layouts/postscript.blade.php
@@ -183,6 +183,22 @@
 		}
 		handlers();
 
+		
+		/**
+		 * Replaces <time>'s content so it complies with the user's time zone
+		 * in /queue and /last-played
+		 */
+		function replaceTimeZones($section) {
+			if ($section.attr('data-uri') == '/queue' || $section.attr('data-uri') == '/last-played') {
+				$section.find('time').each(function(){
+					var d = new Date(this.getAttribute('datetime'));
+					this.firstChild.nodeValue = d.toLocaleTimeString();
+				});
+			}
+		}
+		replaceTimeZones($('.radio-content-panel.current'));
+
+
 		$(window).on("statechange", function(event) {
 			var state = History.getState();
 			var root = History.getRootUrl();
@@ -305,6 +321,8 @@
 								$current.remove();
 							}
 							
+							replaceTimeZones($section);
+
 							$section.appendTo($("#radio-container")).addClass("current").show();
 
 							handlers();

--- a/public/css/base.css
+++ b/public/css/base.css
@@ -218,5 +218,5 @@ li#nav-control > div > div.popover-content {
 }
 .time-list span {
     display: table-cell;
-    padding: 8px 15px 8px 0px;
+    padding: 8px 15px;
 }

--- a/public/css/base.css
+++ b/public/css/base.css
@@ -212,8 +212,11 @@ li#nav-control > div > div.popover-content {
 .time-list .list-group-item {
     display: table-row;
 }
-.time-list span, .time-list time {
+.time-list time {
     display: table-cell;
     padding: 8px 0px 8px 15px;
 }
-
+.time-list span {
+    display: table-cell;
+    padding: 8px 15px 8px 0px;
+}

--- a/public/css/base.css
+++ b/public/css/base.css
@@ -206,3 +206,14 @@ li#nav-control > div > div.popover-content {
     display: none;
 }
 
+.time-list {
+    display: table;
+}
+.time-list .list-group-item {
+    display: table-row;
+}
+.time-list span, .time-list time {
+    display: table-cell;
+    padding: 8px 0px 8px 15px;
+}
+


### PR DESCRIPTION
Fix for issue #61. Added a `replaceTimeZones` function in the javascript and changed a `<span>` to `<time>` because /queue has it like this.