### PR TITLE
Update base.css

### DIFF
--- a/public/css/base.css
+++ b/public/css/base.css
@@ -61,9 +61,6 @@
     padding-left: 0;
     padding-right: 0;
 }
-#np {
-    padding-top: 20px;
-}
 #audio-play, #audio-pause {
     cursor: pointer;
 }


### PR DESCRIPTION
remove useless padding that overlaps when text wraps around that makes copying the artist or title annoying.