### PR TITLE
add pending track count on submit page

### DIFF
--- a/app/controllers/Home.php
+++ b/app/controllers/Home.php
@@ -353,6 +353,9 @@ class Home extends BaseController {
 			->where("ip", "=", Request::server("REMOTE_ADDR"))
 			->count();
 
+		$pending_amount = DB::table("pending")
+			->count();
+
 		$replacements = Track::where("need_reupload", 1)->get();
 
 		$uploadTime = $this->checkUploadTime();
@@ -371,7 +374,8 @@ class Home extends BaseController {
 			->with("ip_decs", $ip_decs)
 			->with("replacements", $replacements)
 			->with("message", $message)
-			->with("cooldown", $cooldown);
+			->with("cooldown", $cooldown)
+			->with("pending_amount", $pending_amount);
 	}
 
 	public function postSubmit() {

--- a/app/views/default/submit.blade.php
+++ b/app/views/default/submit.blade.php
@@ -17,6 +17,7 @@
 					<strong>{{{ trans("submit.guidelines.upload.title") }}}</strong>
 					<ul>
 						<li>{{{ trans("submit.guidelines.upload.search") }}}</li>
+						<li>Low quality uploads are likely to be declined if it's obvious better quality versions are available</li>
 						<li>{{{ trans("submit.guidelines.upload.quality") }}}</li>
 						<li>{{{ trans("submit.guidelines.upload.source") }}}</li>
 					</ul>
@@ -27,6 +28,7 @@
 						<li>{{{ trans("submit.guidelines.tagging.required") }}}</li>
 						<li>{{{ trans("submit.guidelines.tagging.runes") }}}</li>
 						<li>{{{ trans("submit.guidelines.tagging.cv") }}}</li>
+						<li>If you can remember, please include where you downloaded the file from</li>
 					</ul>
 				</p>
 			</div>

--- a/app/views/default/submit.blade.php
+++ b/app/views/default/submit.blade.php
@@ -96,6 +96,13 @@
 		</div>
 
 		<div class="row">
+			<br>
+			<div class="alert text-center">
+				There are currently {{{ count($pending) }}} pending tracks awaiting approval.
+			</div>
+		</div>
+
+		<div class="row">
 			<hr>
 			<div class="col-md-6">
 				<h2 class="text-success text-center">{{{ trans("submit.accepts") }}}</h2>

--- a/app/views/default/submit.blade.php
+++ b/app/views/default/submit.blade.php
@@ -100,7 +100,7 @@
 		<div class="row">
 			<br>
 			<div class="alert text-center">
-				There are currently {{{ count($pending) }}} pending tracks awaiting approval.
+				There are currently {{{ $pending_amount }}} pending tracks awaiting approval.
 			</div>
 		</div>
 

--- a/app/views/partials/help-main.blade.php
+++ b/app/views/partials/help-main.blade.php
@@ -20,6 +20,11 @@
 				<p>Search for a song first, by entering something into the searchbox at the top (or clicking "Search" in the navbar).</p>
 				<p>Then, click on <button class="btn btn-success btn-sm">Request</button></p>
 				<p>You can only request every 30 minutes.</p>
+
+				<h3>Submitting songs</h3>
+				<p>Head over to the <a href="/submit">submit page</a> and read the instructions on the left <b>very carefully</b> before submitting a song.</p>
+				<p>It can take some time for your submission to be reviewed and accepted (or declined).</p>
+				<p>Your submission may be declined for a number of reasons including low quality, missing tags (meaning artist name, song name, source, etc.), but also sometimes because it's simply too niche and the majority of the listeners would likely rather not listen to it.</p>
 			</div>
 			<div class="modal-footer">
 				<button type="button" class="btn btn-default" data-dismiss="modal">Close</button>


### PR DESCRIPTION
I don't know if this works because I can't test it (the vagrant meme doesn't work anymore and I couldn't be bothered trying to fix it).

I just copied the pending tracks part from accept page to submit page because I think it's reasonable to let people know how long they might have to wait for their submission to be accepted.