### PR TITLE
Allow ~ in search queries.

### DIFF
--- a/app/traits/SearchTrait.php
+++ b/app/traits/SearchTrait.php
@@ -134,6 +134,7 @@ trait SearchTrait {
 				"?",
 				"\\",
 				"/",
+				"~",
 			],
 			[
 				"",
@@ -149,6 +150,7 @@ trait SearchTrait {
 				"",
 				"",
 				"",
+				" ",
 			],
 			$text
 		);


### PR DESCRIPTION
Handle '~' the same way '-' gets handled in search queries.